### PR TITLE
DEVPROD-3527 Create a python script to tell DSI that a new phase begun

### DIFF
--- a/notify_phase_end.py
+++ b/notify_phase_end.py
@@ -11,18 +11,13 @@ from argparse import ArgumentParser
 import json
 
 parser = ArgumentParser()
-parser.add_argument("phase_id", type=int, help="Number of the phase that ended")
-parser.add_argument("-n", "--phase_name", type=str, help="Name of the phase that ended")
-parser.add_argument(
-    "-i", "--ip", type=str, default="0.0.0.0", help="Ip to send the notification to"
-)
-parser.add_argument("-p", "--port", type=int, default=4400, help="Port to send the notification to")
+parser.add_argument("phase_name", type=str, help="Name of the phase that ended")
+parser.add_argument("-i", "--ip", type=str, default="0.0.0.0", help="Target ip for the notification")
+parser.add_argument("-p", "--port", type=int, default=4400, help="Target port for the notification")
 args = parser.parse_args()
 
 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
     s.connect((args.ip, args.port))
     message = {"message": "Ending phase"}
-    message["phase"] = args.phase_id
-    if args.phase_name:
-        message["phase_name"] = args.phase_name
+    message["phase"] = args.phase_name
     s.send((json.dumps(message) + "\n").encode())

--- a/notify_phase_end.py
+++ b/notify_phase_end.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+"""
+This script is used by various workloads to notify DSI that a phase within a workload ended.
+The messages from this script are parsed by DSI's PortForwardedEventQueue in events.py.
+If profiling is enabled, this will trigger DSI to stop any profilers that are currently running.
+"""
+
+import socket
+from argparse import ArgumentParser
+import json
+
+parser = ArgumentParser()
+parser.add_argument("phase_id", type=int, help="Number of the phase that ended")
+parser.add_argument("-n", "--phase_name", type=str, help="Name of the phase that ended")
+parser.add_argument(
+    "-i", "--ip", type=str, default="0.0.0.0", help="Ip to send the notification to"
+)
+parser.add_argument("-p", "--port", type=int, default=4400, help="Port to send the notification to")
+args = parser.parse_args()
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+    s.connect((args.ip, args.port))
+    message = {"message": "Ending phase"}
+    message["phase"] = args.phase_id
+    if args.phase_name:
+        message["phase_name"] = args.phase_name
+    s.send((json.dumps(message) + "\n").encode())

--- a/notify_phase_start.py
+++ b/notify_phase_start.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+"""
+This script is used by various workloads to notify DSI that a phase within a workload started.
+The messages from this script are parsed by DSI's PortForwardedEventQueue in events.py.
+If profiling is enabled, this will trigger DSI to stop any profilers that are currently running.
+"""
+
+import socket
+from argparse import ArgumentParser
+import json
+
+parser = ArgumentParser()
+parser.add_argument("phase_id", type=int, help="Number of the phase that started")
+parser.add_argument("-n", "--phase_name", type=str, help="Name of the phase that started")
+parser.add_argument(
+    "-i", "--ip", type=str, default="0.0.0.0", help="Ip to send the notification to"
+)
+parser.add_argument("-p", "--port", type=int, default=4400, help="Port to send the notification to")
+args = parser.parse_args()
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+    s.connect((args.ip, args.port))
+    message = {"message": "Beginning phase"}
+    message["phase"] = args.phase_id
+    if args.phase_name:
+        message["phase_name"] = args.phase_name
+    s.send((json.dumps(message) + "\n").encode())

--- a/notify_phase_start.py
+++ b/notify_phase_start.py
@@ -11,18 +11,13 @@ from argparse import ArgumentParser
 import json
 
 parser = ArgumentParser()
-parser.add_argument("phase_id", type=int, help="Number of the phase that started")
-parser.add_argument("-n", "--phase_name", type=str, help="Name of the phase that started")
-parser.add_argument(
-    "-i", "--ip", type=str, default="0.0.0.0", help="Ip to send the notification to"
-)
-parser.add_argument("-p", "--port", type=int, default=4400, help="Port to send the notification to")
+parser.add_argument("phase_name", type=str, help="Name of the phase that started")
+parser.add_argument("-i", "--ip", type=str, default="0.0.0.0", help="Target ip for the notification")
+parser.add_argument("-p", "--port", type=int, default=4400, help="Target port for the notification")
 args = parser.parse_args()
 
 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
     s.connect((args.ip, args.port))
     message = {"message": "Beginning phase"}
-    message["phase"] = args.phase_id
-    if args.phase_name:
-        message["phase_name"] = args.phase_name
+    message["phase"] = args.phase_name
     s.send((json.dumps(message) + "\n").encode())


### PR DESCRIPTION
This PR adds two Python scripts that can be used by workloads to notify DSI that a new phase has begun, which will cause DSI to restart the profilers.

### Why are the scripts in this repo?
These scripts would semantically make the most sense in the DSI repo. However, when running DSI locally, a) the DSI folder is not rsynced to the workload client, and b) the DSI folder on the local machine is in the directory above the work directory, while on Evergreen it's located in src/dsi. See [this Slack discussion](https://mongodb.slack.com/archives/C044WBW0189/p1704728988752149) for more details.

### Why two scripts instead of one?
Making start/stop an argument of this script would duplicate the code for this. However, this would significantly reduce the readability of the calls to the script.

### Patch showing how this script could be used
[YCSB-example](https://evergreen.mongodb.com/filediff/659d2b732a60ed19c4ac1c71/?file_name=configurations%2Ftest_control%2Ftest_control.ycsb.yml&patch_number=1&commit_number=0)
https://spruce.mongodb.com/version/659d2b732a60ed19c4ac1c71