### PR TITLE
DEVPROD-3527 Update phase scripts to wait for DSI to finish

### DIFF
--- a/notify_phase_end.py
+++ b/notify_phase_end.py
@@ -20,4 +20,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
     s.connect((args.ip, args.port))
     message = {"message": "Ended phase"}
     message["phase"] = args.phase_name
+    message["request"] = 1
     s.send((json.dumps(message) + "\n").encode())
+    # Wait until DSI finishes responding to phase changes
+    resp = s.recv(1024)

--- a/notify_phase_start.py
+++ b/notify_phase_start.py
@@ -20,4 +20,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
     s.connect((args.ip, args.port))
     message = {"message": "Beginning phase"}
     message["phase"] = args.phase_name
+    message["request"] = 1
     s.send((json.dumps(message) + "\n").encode())
+    # Wait until DSI finishes responding to phase changes
+    s.recv(1024)


### PR DESCRIPTION
This PR updates the phase scripts to request a response from DSI once it is finished reacting to the phase change and stall until this response is received.

This is necessary because, for very short phases, we can otherwise run into an issue where the start phase event triggers DSI to start the profilers, but before this finishes, the phase already ends again, and DSI attempts to stop the profilers in response to the phase end event. In this scenario, the profilers never get shut down after they eventually finish starting.

Patch:
https://spruce.mongodb.com/version/65a12ad43627e04719ddf22d/

This still prints an error message about the command to stop the profilers failing, but this is misleading as the profilers are stopped successfully. I'll address this error message in another PR in the context of [DEVPROD-3699](https://jira.mongodb.org/browse/DEVPROD-3699).